### PR TITLE
Passing Options Array to API

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -467,7 +467,7 @@ class Client
                 'headers' => [
                     'Authorization' => $this->authToken
                 ],
-                'json' => [
+                'json' => $options + [
                     'bucketId' => $options['BucketId'],
                     'startFileName' => $nextFileName,
                     'maxFileCount' => $maxFileCount,


### PR DESCRIPTION
As documented in the B2 API, b2_list_file_names calls can be customized for different results by using params like delimiter or prefix.
I want to make sure if this repo is accepting PRs so maybe improve other parts of the API as well.

For more details on b2_list_file_names endpoint: https://www.backblaze.com/b2/docs/b2_list_file_names.html