### PR TITLE
Added property to fix PHP 8.2 warnings

### DIFF
--- a/src/Object/File/FileUploadMetadata.php
+++ b/src/Object/File/FileUploadMetadata.php
@@ -20,6 +20,9 @@ final class FileUploadMetadata {
 	/** @var string */
 	private $hash;
 
+	/** @var int|null */
+	private $mtime;
+
 	/**
 	 * @param int $length 
 	 * @param string $hash 


### PR DESCRIPTION
Added the property $mtime to avoid the following error:

Creation of dynamic property Zaxbux\BackblazeB2\Object\File\FileUploadMetadata::$mtime is deprecated